### PR TITLE
Replace ODBC backend with a web API backend

### DIFF
--- a/AddinFiles/addinload.jsl
+++ b/AddinFiles/addinload.jsl
@@ -14,17 +14,22 @@ If(
 ns:addinhome = "$ADDIN_HOME(" || thisAddIn || ")\";
 
 //read a file with information about the add-in (name, developer, etc)
-ns:metadata_aa = Include( ns:addinhome || "customMetadata.jsl" );
+ns:metadata_aa = Include( "customMetadata.jsl" );
 
 //load misc functions used across the whole add-in,
 //and functions to log usage information, check for updates, and store user preferences
-Include( ns:addinhome || "addinLog.jsl" );
-Include( ns:addinhome || "addinTools.jsl" );
-Include( ns:addinhome || "addinUserPref.jsl" );
+Include( "addinLog.jsl" );
+Include( "addinTools.jsl" );
+Include( "addinUserPref.jsl" );
+Include( "queries.jsl" );
+
+// This is the most rows that the web API can return
+ns:APIRowLimit = 150000;
 
 //set default preference values
 ns:DefaultPref = Associative Array({
 	{"PI_Server", "My PI Archive"},
+	{"Base_Url", "https://localhost/piwebapi"},
 	{"Max_Rows", "10000"},
 	{"Open_Script_Windows", "no"}
 });
@@ -32,7 +37,12 @@ ns:DefaultPref = Associative Array({
 //set preference types, descriptions, and value restrictions
 ns:PrefInfo = Associative Array({
 	{"PI_Server", {
-		"ODBC connection name of the default PI Server.",
+		"Name of the default PI Web Server.",
+		"char",
+		{}
+	}},
+	{"Base_Url", {
+		"Base URL to access the PI Web API.",
 		"char",
 		{}
 	}},
@@ -42,7 +52,7 @@ ns:PrefInfo = Associative Array({
 		{}
 	}},
 	{"Open_Script_Windows", {
-		"Should SQL and JSL windows be open by default (yes/no)?",
+		"Should JSL script window be open by default (yes/no)?",
 		"char",
 		{"yes", "no"}
 	}}

--- a/AddinFiles/main.jsl
+++ b/AddinFiles/main.jsl
@@ -1,7 +1,6 @@
 ﻿/* About: Get OSI PI Data
 
-Get data from PI Servers, requires prior set up of PI DAX, OLE-DB and ODBC
-and odbc connections.
+Get data from PI Web API. Requires version 2021 SP3 or higher of the PI Web API.
 
 Section: Globals
 */
@@ -20,6 +19,7 @@ If(
 );
 ns:logusage( "Get PI Data" );
 
+
 //Standard box to display description for each input
 tbDesc = Function( {descmsg, helpmsg, wdth = 100},
 	Eval( Eval Expr(  VCenter Box( 
@@ -32,14 +32,13 @@ tbDesc = Function( {descmsg, helpmsg, wdth = 100},
 );
 
 //Standard box to get text info from the user
-tebText = Function( {initval, varname, helpmsg = "", wdth = 150, nlines = 1,
+tebText = Function( {initval, varname, helpmsg = "", wdth = 150,
 		fn = function( {this}, UpdateOutput(); ) },
 	centeredbox = Eval( (  VCenter Box( 
 		tbtemp = Text Edit Box(
 			initval,
 			<< Justify Text( Left ),
 			<< Set Width( wdth ),
-			<< setNlines( nlines ),
 			<< SetFunction( fn ),
 			<< Set Tip( helpmsg )
 		),
@@ -76,7 +75,8 @@ sbDefault = Function( {}, Spacer Box( Size( 3, 3 ) ) );
 
 //Standard line for text input
 stdtxtInput = Function( { varname, descmsg, initval, helpmsg, nlines = 1, descwidth = 100,
-	fn = function( {this}, UpdateOutput(); ) },
+		fn = function( {this}, UpdateOutput(); ) },
+
 	Eval( Eval Expr(
 		H List Box(
 			tbDesc( Expr( descmsg ), helpmsg ),
@@ -111,7 +111,7 @@ DefaultTableFormat = function( {},
 );
 
 SizeTextBoxes = function( {},
-	boxes = { {TagList, TagListsb}, {SQLin, SQLinsb}};
+	boxes = { {TagList, TagListsb} };
 	for(i = 1, i <= N Items(boxes), i++,
 		Eval( Eval Expr( 
 			tbtmp = Text Box( Expr( boxes[i][1] ) << Get Text, set wrap( Expr( boxes[i][1] ) << Get Wrap), set width( Expr( boxes[i][1] ) << Get Width ), hide(0)); 
@@ -128,17 +128,7 @@ SizeTextBoxes = function( {},
 	
 );
 
-//function to set up searchfield to allow or disallow expressions
-allowExpr = function( {allowed},
-	Prevval = rb_searchfield << Get;
-	If( allowed == 1,
-		rb_searchfield << Set Items( {"tag", "descriptor", "expression"} ),
-		rb_searchfield << Set Items( {"tag", "descriptor"} )
-	);
-	rb_searchfield << Set ( Prevval );
-);
-
-//Set text boxes with SQL and JSL
+// Set textbox with JSL
 UpdateOutput = function( {},
 	
 	if( DisableUpdate == 1, return());
@@ -152,7 +142,7 @@ UpdateOutput = function( {},
 	);
 
 	querytype = rb_querytype << Get Selected;
-	
+	calctype = rb_calctype << Get Selected;
 	searchfield = rb_SearchField << Get Selected;
 	
 	//Show or hide time options
@@ -165,7 +155,7 @@ UpdateOutput = function( {},
 		lb_matchtype << Visibility("visible");
 		rb_tblformat << Set( 1 );
 		lb_longwide << Visibility("collapse");
-		allowExpr( 0 ),
+	,
 	
 		querytype == "Snapshot Values",
 		querytimes << Visibility("collapse");
@@ -176,7 +166,7 @@ UpdateOutput = function( {},
 		lb_matchtype << Visibility("visible");
 		rb_tblformat << Set( 1 );
 		lb_longwide << Visibility("collapse");
-		allowExpr( 0 ),
+	,
 		
 		querytype == "All Archived Values",
 		querytimes << Visibility("visible");
@@ -186,7 +176,7 @@ UpdateOutput = function( {},
 		lb_searchfield << Visibility("visible");
 		lb_matchtype << Visibility("visible");
 		lb_longwide << Visibility("visible");
-		allowExpr( 0 ),
+	,
 		
 		querytype == "Interpolated Values",
 		querytimes << Visibility("visible");
@@ -196,7 +186,7 @@ UpdateOutput = function( {},
 		lb_searchfield << Visibility("visible");
 		lb_matchtype << Visibility("visible");
 		lb_longwide << Visibility("visible");
-		allowExpr( 1 ),
+	,
 		/*
 		querytype == "Calculated Expression",
 		querytimes << Visibility("visible");
@@ -210,28 +200,39 @@ UpdateOutput = function( {},
 		*/
 		querytimes << Visibility("visible");
 		lb_intervaltime << Visibility("visible");
-		lb_steptime << Visibility("visible");
+		// Separate step time only allowed for TimeWeighted basis
+		if(calctype == "TimeWeighted",
+			lb_steptime << Visibility("visible")
+		,
+			TimeStep << Set Text (TimeInterval << Get Text);
+			lb_steptime << Visibility("collapse")
+		);
 		lb_CalcBasis << Visibility("visible");
 		lb_searchfield << Visibility("visible");
 		lb_matchtype << Visibility("visible");
 		lb_longwide << Visibility("visible");
-		allowExpr( 1 ),
 	);
-	
+
 	//If step and interval times are linked, update the interval time
 	If( ( SeparateInterval << Get ) == 1,
-		lb_steptimesub << Visibility("visible");,
+		lb_steptimesub << Visibility("visible");
+	,
 		lb_steptimesub << Visibility("collapse");
 		TimeStep << Set Text( TimeInterval  << Get Text );
 	);
-
-	SQLin << set text( BuildSQL() );
 	
-	JSLout << set text( BuildJSL() );
+	JSLout << set text( Char(BuildJSL()) );
+	// Open the outline box before reformatting or the JSL gets formatted for very narrow script box
+	wasOpen = obJSLScript << GetOpen;
+	obJSLScript << setopen(1);
+	JSLout << Reformat;
+	obJSLScript << setopen(wasOpen);
 	
-	If( searchfield == "expression",
-		tb_tagnameshead << Set Text( "Expressions" );
-		lb_matchtype << Visibility("collapse"),
+	If( searchfield == "webID",
+		lb_matchtype << set(1); // Exact matches only
+		tb_tagnameshead << Set Text( "Web IDs" );
+		lb_matchtype << Visibility("collapse")
+	,
 		tb_tagnameshead << Set Text( "Tag Names" );
 		lb_matchtype << Visibility("visible")
 	);
@@ -254,331 +255,192 @@ FieldFromLine = function( {field, line}, {r, rx},
 	return(r);
 );
 
-//SQL statement
-BuildSQL = function({},
-	rsql = "";
-	
-	taglisttxt = Char(TagList << Get Text );
-	txt = taglisttxt || "\!N";
-	
-	//If an expression, then join multiple single calls together, otherwise just call BuildSQLTags.
-	If(
-		(rb_searchfield << Get selected) == "expression"
-	,
-		for ( tg = 1, Contains( txt, "\!N" ) & tg < 100000, tg++,
-			if( Contains( txt, "\!N" ) > 1,
-				if(tg > 1, rsql = rsql || "\!NUNION ALL\!N" );
-				tmptxt = FieldFromLine( "tag", txt );
-				rsql = rsql || BuildSQLTags( tmptxt );
-			);
-		
-			txt = substr( txt, Contains( txt, "\!N") + 2, length(txt) );
-			
-		);
-	,
-		rsql = BuildSQLTags(taglisttxt);
-	);
-	
-	return(rsql);
-);
-
-//Create sql statement for tag or description queries, or a single expression query
-BuildSQLTags = function( {taglisttxt}, {txt},
-	
-	querytype = rb_querytype << Get Selected;
-	
-	searchfield = rb_SearchField << Get Selected;
-	
-	if (//Point Info
-		querytype == "Point Info",
-		SQLtext = "SELECT TOP " || char(MaxRows << Get Text) || " tag, descriptor, engunits, *" /*" tag, descriptor, engunits, pointtypex, pointsource, 
-			archiving, changedate, changer, compdev, compdevpercent, compmax, 
-			compmin, compressing, convers, creationdate, creator, dataaccess, datagroup, 
-			dataowner, dignumber, digstartcode, displaydigits,  
-			excdev, excdevpercent, excmax, excmin, exdesc, filtercode, instrumenttag, 
-			location1, location2, location3, location4, location5, pointaccess, 
-			pointclass, pointgroup, pointid, pointnumber, pointowner, 
-			pointtype, recordtype, res, scan, shutdown, sourcetag, span, 
-			squareroot, step, totalcode, typicalvalue, userint1, userint2, 
-			userreal1, userreal2, zero " */ ||
-		"\!NFROM [pipoint]..[pipoint]" ||
-		"\!NWHERE (" || BuildTagList(taglisttxt) || ")",
-		
-		//Snapshot Values
-		querytype == "Snapshot Values",
-		SQLtext = "SELECT TOP " || char(MaxRows << Get Text) || " tag, time, value, svalue, DIGSTRING(status) status" ||
-		"\!NFROM piarchive..picomp" ||
-		"\!NWHERE (" || BuildTagList(taglisttxt) ||
-		")\!N	AND time = '*'";,
-		
-		//Archived Values
-		querytype == "All Archived Values",
-		SQLtext = "SELECT TOP " || char(MaxRows << Get Text) || " tag, time, value, svalue, DIGSTRING(status) status" ||
-		"\!NFROM piarchive..picomp" ||
-		"\!NWHERE (" || BuildTagList(taglisttxt) ||
-		")\!N	AND time >= '" || char(TimeStart << Get Text) || 
-		"' AND time <= '" || char(TimeEnd << Get Text) || "'";,
-		
-		//Interpolated values
-		querytype == "Interpolated Values",
-		SQLtext = "SELECT TOP " || char(MaxRows << Get Text) || 
-		If( 
-			searchfield == "expression", 
-			" expr, time, CAST( value AS Float64 ) as value", 
-			" tag, time, value, svalue, DIGSTRING(status) status"
-		) ||
-		"\!NFROM piarchive.." || If( searchfield == "expression", "picalc", "piinterp" ) ||
-		"\!NWHERE (" || BuildTagList(taglisttxt) ||
-		")\!N	AND time BETWEEN '" || char(TimeStart << Get Text) || 
-		"' AND '" || char(TimeEnd << Get Text) || 
-		"' AND timestep = '" || char(TimeStep << Get Text) || "'";,
-		/*
-		//Calculated Expression
-		querytype == "Calculated Expression",
-		SQLtext = "SELECT TOP " || char(MaxRows << Get Text) || " expr, time, CAST( value AS Float64 ) as value" ||
-		"\!NFROM piarchive..picalc" ||
-		"\!NWHERE (" || BuildTagList(taglisttxt) ||
-		")\!N	AND time BETWEEN '" || char(TimeStart << Get Text) || 
-		"' AND '" || char(TimeEnd << Get Text) || 
-		"' AND timestep = '" || char(TimeStep << Get Text) || "'";,
-		*/
-		//Calculated values: Average
-		querytype == "Average",
-		SQLtext = AggregateSQL("piavg", taglisttxt),
-		
-		//Calculated values: count
-		querytype == "Count",
-		SQLtext = AggregateSQL("picount", taglisttxt),
-		
-		//Calculated values: max
-		querytype == "Max",
-		SQLtext = AggregateSQL("pimax", taglisttxt),
-		
-		//Calculated values: max
-		querytype == "Mean",
-		SQLtext = AggregateSQL("pimean", taglisttxt),
-		
-		//Calculated values: max
-		querytype == "Min",
-		SQLtext = AggregateSQL("pimin", taglisttxt),
-		
-		//Calculated values: max
-		querytype == "Population Standard Deviation",
-		SQLtext = AggregateSQL("pipstd", taglisttxt),
-		
-		//Calculated values: max
-		querytype == "Range",
-		SQLtext = AggregateSQL("pirange"),
-		
-		//Calculated values: max
-		querytype == "Standard Deviation",
-		SQLtext = AggregateSQL("pistd", taglisttxt),
-		
-		//Calculated values: max
-		querytype == "Totals",
-		SQLtext = AggregateSQL("pitotal", taglisttxt),
-		
-		//Calculated values: max
-		querytype == "Calculated Expression",
-		SQLtext = AggregateSQL("picalc", taglisttxt)
-		
-	);
-	
-	Return( SQLtext );
-);
-
-//SQL statement for all aggregate functions such as min, max, average, etc
-AggregateSQL = function({tblName, taglisttxt}, {txt},
-	SQLtext = "SELECT TOP " || char(MaxRows << Get Text) || " *" ||
-		"\!NFROM piarchive.." || char(tblName) ||
-		"\!NWHERE (" || BuildTagList(taglisttxt) ||
-		")\!N	AND " ||
-		if( TimeStep == "", 
-			//No timestep - standard call
-			"time BETWEEN '" || char(TimeStart << Get Text) || 
-			"' AND '" || char(TimeEnd << Get Text) || 
-			"' AND timestep = '" || char(TimeInterval << Get Text) || "'",
-			
-			//With timestep - call as a list of times
-			"time IN(SELECT time FROM piarchive..piinterp2 " ||
-			"WHERE tag = 'sinusoid'" ||
-			"AND time BETWEEN '" || char(TimeStart << Get Text) || 
-			"' AND '" || char(TimeEnd << Get Text) || 
-			"' AND timestep = '" || char(TimeStep << Get Text) ||
-			"') AND timestep = '" || char(TimeInterval << Get Text) || "'"
-		) ||
-			
-		" AND calcbasis = '" || char(rb_calctype << Get Selected) || "'";
-		
-	Return( SQLtext );
-);
-
-//Create the part of the SQL statement containing tag names
-BuildTagList = function ( {taglisttxt}, {txt},
-	querytype = rb_querytype << Get Selected;
-	
-	searchfield = rb_SearchField << Get Selected;
-	
-	If( searchfield == "expression", searchfield = "expr" );
-	
-	txt = taglisttxt || "\!N";
-	
-	tags = "";
-	
-	for ( tg = 1, Contains( txt, "\!N" ) & tg < 100000, tg++,
-		if( Contains( txt, "\!N" ) > 1,
-			If( !Is Missing( FieldFromLine( "tag", txt ) ), 
-				//create an 'in' statement if looking for an exact match, otherwise a like statement
-				if( (rb_matchtype << get selected) == "Exact",
-					tags = tags || if ( tg == 1, searchfield || " IN (", ",") || "'";,
-					tags = tags || if ( tg == 1, searchfield || " LIKE ", " OR " || searchfield || " LIKE ") || "'";
-				);
-				
-				//enclose tag in single quotes
-				tags = tags ||
-					if( Contains Item( "Ends with,Contains", two_rb = (rb_matchtype << get selected), "," ) == 1, "%", "") || 
-					FieldFromLine( "tag", txt ) ||
-					if( Contains Item( "Starts with,Contains", two_rb = (rb_matchtype << get selected), "," ) == 1, "%", "") || "'";
-			)
-		);
-		
-		txt = substr( txt, Contains( txt, "\!N") + 2, length(txt) );
-	);
-	
-	//add closing ')' if creating an 'in' statement
-	if( (rb_matchtype << get selected) == "Exact",
-		tags = tags || ")";,
-	);
-	
-	Return(tags);
-);
 
 //Create JSL script from options on the form.
 BuildJSL = function( {}, {txt},
 
+	// Get inputs
+	serverName = Server << GetText;
 	querytype = rb_querytype << Get Selected;
-	
 	searchfield = rb_SearchField << Get Selected;
-	
 	cnformat = cb_cnformat << Get Selected;
+	matchType = rb_matchtype << Get Selected;
+	searchStrings = Words( TagList << Get Text, "\!N");
+	calculationBasis = rb_calctype << GetSelected;
+	startTime = TimeStart << GetText;
+	endTime = TimeEnd << GetText;
+	intervalTime = TimeInterval << GetText;
+	If(SeparateInterval << Get(1) == 0,
+		// Use the interval as the time step if there is no separate interval
+		stepTime = intervalTime
+	,
+		stepTime = TimeStep << GetText
+	);
+	TableFormat = rb_tblformat << getSelected;
 	
-	oldcn = ns:map( Words( TagList << Get Text, "\!N"),
+	oldcn = ns:map(searchStrings,
 		function( {x}, Uppercase( Char( FieldFromLine( "tag", x || "\!N" ) ) ) )
 	);
 	
-	newcn = ns:map( Words( TagList << Get Text, "\!N"),
+	newcn = ns:map(searchStrings,
 		function( {x}, FieldFromLine( cnformat, x || "\!N" ) )
 	);
 	
-	taggroups = ns:map( Words( TagList << Get Text, "\!N"),
+	taggroups = ns:map(searchStrings,
 		function( {x}, FieldFromLine( "group", x || "\!N" ) )
 	);
-	
+
 	ColToSplit = If( 
-		(querytype == "Interpolated Values" |
-		querytype == "All Archived Values") & !( searchfield == "expression" ), 
-		
-		"Split( :value, :svalue, :status )",
-		"Split( :value )";
+		(querytype == "Interpolated Values" | querytype == "All Archived Values"), 
+		{:value, :svalue, :status},
+		{:value}
 	);
-		
-	NewTblExpr = Eval Insert( 
-	
-		"Names default to here(1);" ||
-		
-		"\!N\!Ntry(" ||
-		
-		//Get data in long format
-		"\!N	dtLong = Open Database( \!"DSN=^Conn << Get Text^\!"," ||
-		"\!N		\!"^SQLin << Get Text^\!"" ||
-		"\!N	);" ||
-		
-		"\!N\!N	if(try(if(nrow(dtLong)>0,1,0),0)==0, throw(\!"No data returned\!"));" ||
-		
-		//Warning if too many rows returned
-		"\!N\!N	//Check for too many characters" ||
-		"\!N	If( N row( dtLong ) >= ^char(MaxRows << Get Text)^," ||
-			"\!N		New Window(\!N			\!"Max Rows Exceeded\!",\!N			Modal,\!N		" ||
-			"	Text Box( \!"Met or exceeded the maximum number of rows for \!" ||" ||
-			"\!N				\!"this query. Increase the allowed maxrows or restrict the query. \!" ||" ||
-			"\!N				\!"Some results might be missing.\!"\!N			)\!N		)\!N	);" ||
-		
-		
-		//List of tags
-		"\!N\!N	oldcn = " || Char( oldcn ) || ";" ||
-		"\!N	oldcncorrected = oldcn;" ||
-		
+
+	// Insert all JSL needed to produce the intended table into this Glue expression
+	NewTblExpr = EvalExpr(Glue(
+		NamesDefaultToHere(1);
+		// Requires the addin's namespace
+		nsName = "com.github.himanga.JMPOSIPITools.addinnamespace";
+		If(!Namespace Exists(nsName),
+			ns = New Namespace(nsName),
+			ns = Namespace(nsName)
+		);
+		// Base URL to be used by all requests
+		ns:baseURL = expr(tb_BaseURL << getText);
+		// Max number if items returned used by all requests
+		ns:maxRows = expr(num(tb_maxrows << getText));
+		// Use the minumum of the user specified maxRows and the API Row limit as the number of rows to pull in a single request
+		ns:maxCount = minimum(ns:maxRows, ns:APIRowLimit);
+		// Gets the data server's web ID based on the user's preferences
+		serverid = ns:DataServerIdRequest(expr(serverName));
+	));
+
+	// Get pointIDs
+	If(searchField == "webID",
+		InsertInto(NewTblExpr,
+			evalExpr(pointIDs = expr(searchStrings))
+		)
+	,//else, need to request pointIDs
+		InsertInto(NewTblExpr,
+			evalExpr({pointIDs, pointNames} = ns:PointRequest(serverid, expr(oldcn), expr(searchfield), expr(matchType)))
+		)
+	);
+
+	// Call a Table function depending on the query type
+	tableRequestExpr = Match(querytype,
+		"Point Info",
+			Expr(dtLong = ns:GetPointAttributesTable(pointIDs)),
+		"Snapshot Values",
+			Expr(dtLong = ns:GetSnapshotValuesTable(pointIDs)),
+		"All Archived Values",
+			EvalExpr(dtLong = ns:GetArchiveValuesTable(pointIDs, pointNames, Expr(startTime), Expr(endTime))),
+		"Interpolated Values",
+			EvalExpr(dtLong = ns:GetInterpolatedValuesTable(pointIDs, pointNames, Expr(startTime), Expr(endTime), Expr(intervalTime))),
+		"Average",
+			EvalExpr(dtLong = ns:GetSummaryValuesTableWithStepTime(pointIDs, pointNames, "Average", Expr(calculationBasis), Expr(startTime), Expr(endTime), Expr(intervalTime), Expr(stepTime))),
+		"Count",
+			EvalExpr(dtLong = ns:GetSummaryValuesTableWithStepTime(pointIDs, pointNames, "Count", Expr(calculationBasis), Expr(startTime), Expr(endTime), Expr(intervalTime), Expr(stepTime))),
+		"Max",
+			EvalExpr(dtLong = ns:GetSummaryValuesTableWithStepTime(pointIDs, pointNames, "Maximum", Expr(calculationBasis), Expr(startTime), Expr(endTime), Expr(intervalTime), Expr(stepTime))),
+		"Min",
+			EvalExpr(dtLong = ns:GetSummaryValuesTableWithStepTime(pointIDs, pointNames, "Minimum", Expr(calculationBasis), Expr(startTime), Expr(endTime), Expr(intervalTime), Expr(stepTime))),
+		"Population Standard Deviation",
+			EvalExpr(dtLong = ns:GetSummaryValuesTableWithStepTime(pointIDs, pointNames, "PopulationStdDev", Expr(calculationBasis), Expr(startTime), Expr(endTime), Expr(intervalTime), Expr(stepTime))),
+		"Range",
+			EvalExpr(dtLong = ns:GetSummaryValuesTableWithStepTime(pointIDs, pointNames, "Range", Expr(calculationBasis), Expr(startTime), Expr(endTime), Expr(intervalTime), Expr(stepTime))),
+		"Standard Deviation",
+			EvalExpr(dtLong = ns:GetSummaryValuesTableWithStepTime(pointIDs, pointNames, "StdDev", Expr(calculationBasis), Expr(startTime), Expr(endTime), Expr(intervalTime), Expr(stepTime))),
+		"Totals",
+			EvalExpr(dtLong = ns:GetSummaryValuesTableWithStepTime(pointIDs, pointNames, "Total", Expr(calculationBasis), Expr(startTime), Expr(endTime), Expr(intervalTime), Expr(stepTime))),
+		throw("Unknown query type")
+	);
+	InsertInto(NewTblExpr, NameExpr(tableRequestExpr));
+
+	// Check if user's Max Rows is exceeded. For Point Info and Snapshot Value compare to row count.
+	// For other queries compare to the most data for any one tag pulled.
+	InsertInto(NewTblExpr, EvalExpr(
+		if(!contains({"Point Info", "Snapshot Values"}, expr(querytype)),
+			dtCount = dtLong << summary(group(:tag), "private");
+			rowCount = colMax(column(dtCount, "N Rows"));
+			close(dtCount, "nosave");
+		,
+			rowCount = nRows(dtLong)
+		);
+		if(rowCount >= ns:maxRows,
+			NewWindow("Max Rows Exceeded", <<modal,
+				TextBox(
+					"Met or exceeded the maximum number of rows (" || char(ns:maxRows) ||
+					") for this query. Increase the allowed maxrows or restrict the query. "||
+					" Some results might be missing."
+				)
+			);
+			dtLong << BringWindowToFront;
+		);
+		oldcn = expr(oldcn);
+		oldcncorrected = oldcn;
+	));
+
+	If(cnformat != "tag",
 		//Change Column Names 
-		If ( !( cnformat == "tag"),
-			"\!N\!N	//Change tag or column names" ||
-			"\!N\!N	newcn = " || Char( newcn ) || ";" ||
-			"\!N\!N	For( i = 1, i <= N Rows( dtLong ), i++," ||
-			"\!N		pos = Min( Loc( oldcncorrected, Uppercase( Column( dtLong, \!"" || If( searchfield == "expression", "expr", "tag" ) || "\!" )[i]) ) );" ||
-			"\!N		If( pos > 0," ||
-			"\!N			Column( dtLong, \!"" || If( searchfield == "expression", "expr", "tag" ) || "\!" )[i] = newcn[pos]" ||
-			"\!N		)" ||
-			"\!N	);",
-			""
-		) ||
-		
-		//Convert to wide format
-		If ( TableFormat == "Wide" ,
-			"\!N\!N	//Convert to wide format" ||
-			"\!N	dtWide = dtLong << Split(" ||
-			"\!N		Split By( " || If( searchfield == "expression", ":expr", ":tag" ) || " )," ||
-			"\!N		^ColToSplit^," ||
-			"\!N		Group( :time ),"||
-			"\!N		Remaining Columns( Drop All )," ||
-			"\!N		Sort by Column Property" ||
-			"\!N	);" ||
-			"\!N	dtLong << Close Window;" ||
-		
-			//Add tag names to notes attribute of column
-			If( cb_tagtonotes << Get,
-				"\!N\!N	//Save tag names to columns. " ||
-				"\!N	For( i = 1, i <= N Cols( dtWide ), i++," ||
-				"\!N		cn = Regex( Column( dtWide, i ) << Get Name, \!"((value )|(svalue )|(status ))?(.*)\!", \!"\5\!" );" ||
-				"\!N		If( !Is Missing( cn )," ||
-				"\!N			pos = Min( Loc( " || If( cnformat == "tag", "oldcn", "newcn" ) || ", cn ) );" ||
-				"\!N			If( pos > 0," ||
-				"\!N				Column( dtWide, i ) << Set Property( \!"PI tag\!", oldcncorrected[pos] );" ||
-				"\!N				Column( dtWide, i ) << Set Property( \!"PI Original Column Name\!", Column( dtWide, i ) << Get Name );" ||
-				"\!N				Column( dtWide, i ) << Set Property( \!"PI call type\!", \!"" || querytype || "\!" );" ||
-				"\!N				Column( dtWide, i ) << Set Property( \!"PI interval\!", \!"" || (TimeInterval << Get Text) || "\!" );" ||
-				If( N Items( Loc({"Average", "Count", "Max", "Min", "Population Standard Deviation", "Range", "Standard Deviation", "Totals"}, querytype) )>0, 
-					"\!N				Column( dtWide, i ) << Set Property( \!"PI step\!", \!"" || (TimeStep << Get Text) || "\!" );" ||
-					"\!N				Column( dtWide, i ) << Set Property( \!"PI interval start offset\!", \!"-" || (TimeStep << Get Text) || "\!" );" ||
-					"\!N				Column( dtWide, i ) << Set Property( \!"PI interval end offset\!", \!"\!" );",
-					""
-				) ||
-				"\!N				Column( dtWide, i ) << Set Property( \!"PI DSN\!", \!"" || (Conn << Get Text) || "\!" );" ||
-				"\!N			);" ||
-				"\!N		);" ||
-				"\!N	);",
-				""
+		InsertInto(NewTblExpr, EvalExpr(
+			newcn = expr(newcn);
+			For( i = 1, i <= N Rows( dtLong ), i++,
+				pos = Min( Loc( oldcncorrected, Uppercase( Column( dtLong, "tag" )[i]) ) );
+				If( pos > 0,
+					Column( dtLong, "tag" )[i] = newcn[pos]
+				)
 			)
-			,
-			""
-		) ||
-			
-		"\!N," ||
-		"\!N	throw(\!"Error getting data.  Details: \!" || char( exception_msg ) )" ||
-		"\!N);";
+		))
 	);
-					
-	Return( NewTblExpr );
+
+	If( TableFormat == "Wide",
+		// Make wide table
+		InsertInto(NewTblExpr, EvalExpr(
+			tableName = dtLong << getName;
+			dtWide = dtLong << Split(
+				Split By( :tag ),
+				Split( expr(ColToSplit) ),
+				Group( :time ),
+				Remaining Columns( Drop All ),
+				Sort by Column Property
+			);
+			close(dtLong, "nosave");
+			dtWide << setName(tableName);
+		));
+		If(cb_tagtonotes << Get,
+			// Save column properties
+			InsertInto(NewTblExpr, EvalExpr(
+				For( i = 1, i <= N Cols( dtWide ), i++,
+					cn = Regex( Column( dtWide, i ) << Get Name, "((value )|(svalue )|(status ))?(.*)", "\5" );
+					If( !Is Missing( cn ),
+						pos = Min( Loc( oldcn, cn ) );
+						If( pos > 0,
+							Column( dtWide, i ) << Set Property( "PI tag", oldcncorrected[pos] );
+							Column( dtWide, i ) << Set Property( "PI Original Column Name", Column( dtWide, i ) << Get Name );
+							Column( dtWide, i ) << Set Property( "PI call type", expr(querytype) );
+							Column( dtWide, i ) << Set Property( "PI interval", expr(intervalTime) );
+							Column( dtWide, i ) << Set Property( "PI Server", expr(serverName) );
+							If( contains({"Average", "Count", "Max", "Min", "Population Standard Deviation", "Range", "Standard Deviation", "Totals"}, expr(querytype)), 
+								Column( dtWide, i ) << Set Property( "PI step", expr(stepTime));
+								Column( dtWide, i ) << Set Property( "PI interval start offset", "-" || expr(stepTime));
+								Column( dtWide, i ) << Set Property( "PI interval end offset", "");
+							)
+						);
+					);
+				)
+			))
+		)
+	);
+	Return( NameExpr(NewTblExpr) );
 );
 
-
-//Reference current table
-dt1 = Current Data Table();
 
 //flag to output a bunch of status info to the log file
 debug = 0;
 
 //window box, all code is inside this box
 
-	nw = New Window( "PI Tag ODBC Query Builder",
+	nw = New Window( "PI Web API Query Builder",
 
 		//box to hold spacers on left and right side of data
 		H List Box ( 
@@ -595,26 +457,36 @@ debug = 0;
 				
 					V List Box(
 						
-						//PI ODBC Connection Name
+						//PI Server Name
 						sbDefault(), 
 						
-						stdtxtInput( varname = "Conn",
-							descmsg = "Connection Name", initval = ns:UserPref["PI_Server"], 
-							helpmsg = "Enter the name of an existing ODBC connection on this computer." ||
+						stdtxtInput( varname = "Server",
+							descmsg = "Server Name", initval = ns:UserPref["PI_Server"], 
+							helpmsg = "Enter the name of the PI Web Server." ||
 								"\!N\!NChange the default value using the User Preferences below." ),
+
+						//PI Web API Base URL
+						sbDefault(),
+
+						hlbURL = stdtxtInput( varname = "tb_BaseURL",
+							descmsg = "Web API Base URL", initval = ns:UserPref["Base_Url"], 
+							helpmsg = "Enter the base URL to access the PI Web API." ||
+								"\!N\!NChange the default value using the User Preferences below." );
+						hlbURL[TextEditBox(1)] << setWidth(250);
+						hlbURL,
 						
 						//Max number of values
 						sbDefault(),  
 						
-						stdtxtInput( varname = "maxrows",
+						stdtxtInput( varname = "tb_maxrows",
 							descmsg = "Max rows", 
 							initval = ns:UserPref["Max_Rows"], 
-							helpmsg = "Enter the maximum number of values to return." ),
+							helpmsg = "Enter the maximum number of values to return per tag." ),
 						
 						//radio buttons to choose the type of query
 						panelbox("Query Types",
 							rb_querytype = radio box({ "Point Info", "Snapshot Values", "All Archived Values", 
-								"Interpolated Values", "Average", "Count", "Max", "Mean", "Min", 
+								"Interpolated Values", "Average", "Count", "Max", "Min", 
 								"Population Standard Deviation", "Range", "Standard Deviation", "Totals"},
 								DefaultTableFormat();
 								UpdateOutput();
@@ -720,11 +592,11 @@ debug = 0;
 							//radio buttons to choose whether to search for tag or description
 							lb_searchfield = H List Box(
 								panelbox("Search Field",
-									rb_SearchField = radio box({ "tag", "descriptor"},
+									rb_SearchField = radio box({ "tag", "descriptor", "webID"},
 										UpdateOutput();
 									),
 								),
-								bbHelp( "Search for tag names or descriptions, only works for Point Info queries.", 
+								bbHelp( "Search for tag names, descriptions, or point webIDs.", 
 									HelpType = "stdradio" )
 							),
 							
@@ -866,47 +738,17 @@ debug = 0;
 							)
 						),
 						
-						
-						
 						V list box(
-							//SQL
-							obSQLQuery = Outline Box( "SQL Statement",
-								SQLinsb = Scroll Box( flexible(1),
-									SQLin = Text Edit Box(
-										"",
-										<< Justify Text( Left ),
-										<< Set Width( 300 ),
-										<< setNlines( 10 ),
-										<< set wrap( 2000 ),
-										<< SetFunction( function( {this},
-											SizeTextBoxes();
-											JSLout << set text( BuildJSL() );
-										) )
-									)
-								),
-								<< close;
-								<< outlinecloseorientation( "Vertical" )
-							),
-							Spacer Box( Size( 2, 2 ) ),
-							bbHelp( "This SQL statement is updated to reflect changes in the options in this window." ||
-								"\!N\!NYou can modify the text in this box and then run a query but your changes " ||
-								"will be overwritten the next time any value in the window is changed (except the script, below).",
-								HelpType = "stdoutline"
-							),
-							
-							Spacer Box( Size( 12, 48 ) ),
-							
 							//JSL
 							obJSLScript = Outline Box( "JSL to Run Query",
 								JSLout = Script Box(
-									"", 300, 400
+									"", 750, 400
 								),
 								<< close;
 								<< outlinecloseorientation( "Vertical" )
 							),
 							Spacer Box( Size( 2, 2 ) ),
-							bbHelp( "This script updated to reflect changes in the options in this window," ||
-								"including the SQL statement above. " ||
+							bbHelp( "This script is updated to reflect changes in the options in this window." ||
 								"\!N\!NYou can modify the text in this box and then run the query but your changes " ||
 								"will be overwritten the next time any other value in the window is changed.",
 								HelpType = "stdoutline"
@@ -982,6 +824,7 @@ debug = 0;
 ; //end of window box
 
 
+// Example Queries to load
 exQueries = {
 	{
 		"Find PI Tags",
@@ -1013,7 +856,6 @@ exQueries = {
 		"Interpolated Values",
 		"Return evenly-spaced values for a tag.",
 		{
-			//Conn << Set Text( "180 PI Archive" ),
 			rb_querytype << Set( 4 ),		//Interpolated Values
 			TimeStart << Set Text( "t - 2d" ),
 			TimeEnd << Set Text( "*" ),
@@ -1033,7 +875,6 @@ exQueries = {
 		"Average Value",
 		"Return daily average values",
 		{
-			//Conn << Set Text( "180 PI Archive" ),
 			rb_querytype << Set( 5 ),
 			TimeStart << Set Text( "t - 10d + 6h" ),
 			TimeEnd << Set Text( "t + 6h" ),
@@ -1084,7 +925,6 @@ UpdateOutput();
 
 //Open script windows if user pref is set
 If( ns:UserPref["Open_Script_Windows"] == "yes",
-	obSQLQuery << Set Open;
 	obJSLScript << Set Open;
 );
 

--- a/AddinFiles/queries.jsl
+++ b/AddinFiles/queries.jsl
@@ -1,0 +1,632 @@
+Names Default To Here(1);
+
+// Encodes a string to be URL friendly
+ns:UrlEncode = function({str},
+	substitute(str,
+		"%", "%25", // Substitute % first
+		" ", "%20",
+		"!", "%21",
+		"\!"", "%22",
+		"#", "%23",
+		"$", "%24",
+		"&", "%26",
+		"'", "%27",
+		"(", "%28",
+		")", "%29",
+		"*", "%2A",
+		"+", "%2B",
+		",", "%2C",
+		"-", "%2D",
+		".", "%2E",
+		"/", "%2F",
+		":", "%3A",
+		";", "%3B",
+		"<", "%3C",
+		"=", "%3D",
+		">", "%3E",
+		"?", "%3F",
+		"@", "%40"
+	)
+);
+
+// Returns the UTC to local timezone difference
+// Add to UTC time to get local time
+ns:GetLocalTimeZoneDifference = function({},
+	{DEFAULT LOCAL},
+	try(
+		return(ns:timeDifference)
+	,
+		request = New HTTP Request(
+			URL(ns:baseURL),
+			Method("GET"),
+			password(":")
+		);
+		request << Send;
+		headers = request << Get Response Headers();
+		utc = headers["date"];
+		timeDifference = Round((Today() - utc)/InHours(1)) * InHours(1);
+		// Store the time difference so this query only happens once
+		ns:timeDifference = timeDifference;
+		return(timeDifference)
+	)
+);
+
+// Converts PI times to a timestamp that JMP can use
+// Optionally parse the timestamp into a JMP datetime
+ns:PiTimeToTimestamp = function({piTimes, parseTimestamp=0},
+	{DEFAULT LOCAL},
+	timestamps = {};
+	// Do an empty calculation at a each time just to get a Timestamp back
+	params = ["expression" => 1, "selectedFields" => "Items.Timestamp"];
+	for(i=1, i<=nItems(piTimes), i++,
+		params["time"] = piTimes[i];
+		result = ns:GetRequest("calculation/times/", params);
+		ts = result["Items"][1]["Timestamp"];
+		if(parseTimestamp,
+			ts = ns:ParseDateString(ts)
+		);
+		InsertInto(timestamps, ts);
+	);
+	Return(timestamps)
+);
+
+// Converts PI durations to a length in seconds. e.g. 1h-30m = 1800s
+ns:PiDurationToSeconds = function({piDurations},
+	{DEFAULT LOCAL},
+	piTimes = {};
+	for(i=1, i<=nItems(piDurations), i++,
+		// add each duration to a known time so the two can be compared
+		insertInto(piTimes, "t+"||piDurations[i]);
+	);
+	insertInto(piTimes, "t");
+	times = ns:PiTimeToTimestamp(piTimes, parseTimestamp=1);
+	t_time = times[NItems(times)];
+	durations = {};
+	for(i=1, i<nItems(times), i++,
+		InsertInto(durations, times[i]-t_time)
+	);
+	return(durations)
+);
+
+// Parses dates of the format returned by the web API and returns a local time
+ns:ParseDateString = Function({dateString},
+	{DEFAULT LOCAL},
+	If(EndsWith(dateString, "Z"),
+		// Z suffix means UTC time. Convert to local.
+		dateString = Left(dateString, Length(dateString) - 1);
+		localTime = ParseDate(dateString) + ns:GetLocalTimeZoneDifference();
+		Return(localTime)
+	,
+		Return(ParseDate(dateString))
+	);
+);
+
+// Converts a JMP date to a UTC datestring
+ns:ToDateString = Function({date},
+	{DEFAULT LOCAL},
+	utcDate = date - ns:GetLocalTimeZoneDifference();
+	datestring = FormatDate(utcDate, "yyyy-mm-ddThh:mm:ss");
+	Return(datestring || "Z")
+);
+
+/* Gets a comma separated list of statuses from a result like 
+["Timestamp" => "2022-10-14T18:29:23Z",
+ "UnitsAbbreviation" => "",
+ "Good" => true, "Questionable" => false,
+ "Substituted" => false,
+ "Annotated" => false,
+ "Value" => 98.22586]
+*/
+ns:ExtractStatus = Function({result},
+	{DEFAULT LOCAL},
+	statuses = {};
+	/* Sometimes Value comes back like below and indicates a status
+	"Value": {
+		"Name": "Shutdown",
+		"Value": 254,
+		"IsSystem": true
+	}
+	*/
+	If(IsAssociativeArray(result["Value"]) & contains(result["Value"], "Name"),
+		InsertInto(statuses, result["Value"]["Name"])
+	);
+	keys = {"Good", "Questionable", "Substituted", "Annotated"};
+	For(i=1, i<=nItems(keys), i++,
+		If(result[keys[i]], InsertInto(statuses, keys[i]))
+	);
+	Return(ConcatItems(statuses, ","))
+);
+
+// Sends a GET request to the endpoint with the specified parameters
+ns:GetRequest = Function({endpoint, queryParameters},
+	{DEFAULT LOCAL},
+	baseURL = ns:baseURL;
+	if(!EndsWith(baseURL, "/"),
+		baseURL ||= "/"
+	);
+	request = newHTTPRequest(
+		URL(baseURL || endpoint),
+		Method("GET"),
+		QueryString(queryParameters),
+		Headers( {"Accept: application/json"} ),
+		Password(":")
+	);
+	result = request << send;
+	if(!(request << IsSuccess),
+		errorMessage = (request << GetStatusMessage) || "\!N";
+		try(errorMessage ||= (char(parseJSON(result)["Errors"]) || "\!N"));
+		errorMessage ||= ("\!NLast URL: " || (request << GetLastURL));
+		Throw(errorMessage)
+	);
+	return(parseJSON(result))
+);
+
+// Gets the data server WebId for the given serverName
+ns:DataServerIdRequest = function({serverName},
+	{DEFAULT LOCAL},
+	params = associativeArray();
+	params["name"] = serverName;
+	params["selectedFields"] = "WebId";
+	// https://docs.osisoft.com/bundle/pi-web-api-reference/page/help/controllers/dataserver/actions/getbyname.html
+	result = ns:GetRequest("dataservers", params);
+	if(!contains(result, "WebId"),
+		throw("No data server found with name '"||params["name"] ||"'.")
+	);
+	return(result["WebId"])
+);
+
+// Finds points by tag name or description and returns their WebIDs and names
+ns:PointRequest = Function({dataServerID, searchStrings, searchField, matchType},
+	{DEFAULT LOCAL},
+	if(!contains({"tag", "descriptor"}, searchField),
+		throw("'searchField' must be one of \!"tag\!" or \!"descriptor\!" in 'ns:PointRequest'.")
+	);
+	if(!contains({"Exact", "Starts with", "Ends with", "Contains"}, matchType),
+		throw("'matchType' must be one of \!"Exact\!", \!"Starts with\!", \!"Ends with\!" or \!"Contains\!" in 'ns:PointRequest'.")
+	);
+
+	// Add wildcards to searchString depending on matchType
+	for(i=1, i<=NItems(searchStrings), i++,
+		searchString = searchStrings[i];
+		match(matchType,
+			"Starts with", searchString = searchString || "*",
+			"Ends with", searchString = "*" || searchString,
+			"Contains", searchString = "*" || searchString || "*"
+		);
+		// Quote the searchString to allow white space
+		searchString = "\!"" || searchString || "\!"";
+		// Build the search query string
+		// https://docs.osisoft.com/bundle/pi-web-api-reference/page/help/topics/pipoint-search-query-syntax.html
+		searchString = "(" || searchField || ":" || searchString || ")";
+		searchStrings[i] = searchString;
+	);
+	// Combine all individual queries with ORs
+	searchQuery = ConcatItems(searchStrings, "OR");
+
+	params = associativeArray();
+	params["dataServerWebId"] = dataServerID;
+	params["query"] = searchQuery;
+	params["maxCount"] = ns:maxCount;
+	params["startIndex"] = 0;
+	pointIDs = {};
+	pointNames = {};
+	While(1,
+		// Repeat this query in batches of ns:maxCount number of points
+		// https://docs.osisoft.com/bundle/pi-web-api-reference/page/help/controllers/point/actions/getpointsbysearch.html
+		result = ns:GetRequest("points/search", params);
+
+		items = result["Items"];
+		for(i=1, i<=nItems(items), i++,
+			insertInto(pointIDs, items[i]["WebId"]);
+			insertInto(pointNames, items[i]["Name"]);
+		);
+
+		// Break if there are fewer points than the maximum allowed by the API or if the user's limit is reached
+		if(nItems(items) < ns:maxCount | nItems(pointIDs) >= ns:maxRows,
+			break()
+		);
+		// Start the next query at the next index
+		params["startIndex"] += ns:maxCount;
+	);
+
+	if(!nItems(pointIDs), throw("No points found"));
+
+	return(pointIDs, pointNames)
+);
+
+// Get a table of attributes for each point in pointIDs
+ns:GetPointAttributesTable = function({pointIDs},
+	{DEFAULT LOCAL},
+	dt = NewTable("Point Attributes");
+	colNames = AssociativeArray();
+	allRows = {};
+	// https://docs.osisoft.com/bundle/pi-web-api-reference/page/help/controllers/point/actions/getattributes.html
+	params = ["selectedFields" => "Items.Name;Items.Value"];
+	for(i=1, i<=nItems(pointIDs), i++,
+		endpoint = "points/"|| pointIDs[i] || "/attributes";
+		result = ns:GetRequest(endpoint, params);
+		items = result["Items"];
+
+		attributesRow = {};
+		for(j=1, j<=nItems(items), j++,
+			attributeName = items[j]["Name"];
+			attributeValue = items[j]["Value"];
+			// Collect all possible attributes as column names and track their type
+			colNames[attributeName] = type(attributeValue);
+			// Convert date attributes to numerical dates
+			if(EndsWith(attributeName, "date"),
+				attributeValue = ns:ParseDateString(attributeValue)
+			);
+
+			// Add to {col1 = "value1", col2 = "value2"} list that will be the row
+			InsertInto(attributesRow, EvalExpr(Expr(Parse(attributeName)) = Expr(attributeValue)));
+		);
+		// Keep the rows that should be added
+		InsertInto(allRows, evalList({attributesRow}));
+	);
+	// Create columns in the table
+	for(colName = colNames << First, !isempty(colName), colName = colNames << Next(colName),
+		if(EndsWith(colName, "date"),
+			dt << NewColumn(colName, Numeric, Format("m/d/y h:m:s"), InputFormat("m/d/y h:m:s"))
+		,//else
+			Eval(EvalExpr(
+				dt << NewColumn(colName, Expr(If(colNames[colName] == "String", "Character", "Numeric")))
+			))
+		);
+	);
+	// Add the rows
+	For(i=1, i<=nItems(allRows), i++,
+		Eval(EvalExpr(dt << AddRows(Expr(allRows[i]))));
+	);
+	try(dt << MoveSelectedColumns({"tag", "descriptor", "engunits"}, To first));
+	return(dt)
+);
+
+// Common functionality for point stream endpoints to build a data table
+// with tag, time, value, svalue, and status info for all points in pointIDs
+// Uses adhoc endpoints of streamset to do a single bulk request rather than several individual requests
+// https://docs.osisoft.com/bundle/pi-web-api-reference/page/help/controllers/streamset.html
+ns:BuildTableFromPointStreamSets = function({pointIDs, streamEndpoint, parameters, title},
+	{DEFAULT LOCAL},
+	dt = NewTable(title,
+		NewColumn( "tag", Character),
+		NewColumn( "time",  Numeric, Format("m/d/y h:m:s"), InputFormat("m/d/y h:m:s")),
+		NewColumn( "value", Numeric),
+		NewColumn( "svalue", Character),
+		NewColumn( "status", Character)
+	);
+	
+	If(!StartsWith(streamEndpoint, "/"), streamEndpoint = "/" || streamEndpoint);
+	endpoint = "streamsets" || streamEndpoint;
+	parameters["webId"] = pointIDs; // Pass in a list to make multiple webId parameters
+	parameters["selectedFields"] = "Items";
+	result = ns:GetRequest(endpoint, parameters);
+	points = result["Items"];
+	For(i=1, i<=NItems(points), i++,
+		point = points[i];
+		// Get the list of all results for the point
+		If(Contains(point, "Items"),
+			pointResults = point["Items"]
+		,// else a single item
+			pointResults = EvalList({point["Value"]})
+		);
+
+		// Add rows for all results for the point
+		For(j=1, j<=NItems(pointResults), j++,
+			pointResult = pointResults[j];
+			row = Eval(EvalExpr(
+				{
+					tag = Expr(point["Name"]),
+					time = Expr(ns:ParseDateString(pointResult["Timestamp"])),
+					status = Expr(ns:ExtractStatus(pointResult))
+				}
+			));
+			// Add Value to value or svalue depending on type
+			If(IsString(pointResult["Value"]),
+				InsertInto(row, EvalExpr(svalue = Expr(pointResult["Value"])))
+			,IsNumber(pointResult["Value"]),
+				InsertInto(row, EvalExpr(value = Expr(pointResult["Value"])))
+			);
+			dt << AddRows(row);
+		)
+	);
+	return(dt)
+);
+
+// Get a table of snapshot values for each point in pointIDs
+// https://docs.osisoft.com/bundle/pi-web-api-reference/page/help/controllers/streamset/actions/getendadhoc.html
+ns:GetSnapshotValuesTable = function({pointIDs},
+	ns:BuildTableFromPointStreamSets(pointIDs, "end", [=>], "Snapshot Values")
+);
+
+
+// Get an list of archive values for the given pointID between start and end times
+// https://docs.osisoft.com/bundle/pi-web-api-reference/page/help/controllers/stream/actions/getrecorded.html
+ns:GetArchiveValues = function({pointID, startTime, endTime},
+	{DEFAULT LOCAL},
+	parameters = AssociativeArray();
+	parameters["selectedFields"] = "Items";
+	parameters["maxCount"] = ns:maxCount;
+	parameters["startTime"] = startTime;
+	parameters["endTime"] = endTime;
+
+	endpoint = "streams/" || pointID || "/recorded";
+	archiveValues = {};
+	While(1,
+		result = ns:GetRequest(endpoint, parameters);
+		items = result["Items"];
+		InsertInto(archiveValues, items);
+
+		// Break if there are fewer points than the maximum allowed by the API or if the user's limit is reached
+		If(nItems(items) < ns:maxCount | nItems(archiveValues) >= ns:maxRows,
+			Break()
+		);
+		// Otherwise, increase the startTime parameter to be the last end time + 1ms so that the last time is not included again
+		lastTime = items[nItems(items)]["Timestamp"] || "+1ms";
+		parameters["startTime"] = lastTime;
+	);
+	Return(archiveValues)
+);
+
+// Get a table of archive values for each point in pointIDs between start and end times
+ns:GetArchiveValuesTable = function({pointIDs, pointNames, startTime, endTime},
+	{DEFAULT LOCAL},
+	dt = NewTable("Archive Values",
+		NewColumn( "tag", Character),
+		NewColumn( "time",  Numeric, Format("m/d/y h:m:s"), InputFormat("m/d/y h:m:s")),
+		NewColumn( "value", Numeric),
+		NewColumn( "svalue", Character),
+		NewColumn( "status", Character)
+	);
+
+	// Fix start and end times so all requests use the same times where e.g. if the endTime is *
+	if(nItems(pointIDs) > 1,
+		{fixedStartTime, fixedEndTime} = ns:PiTimeToTimestamp(evalList({startTime, endTime}));
+	,
+		fixedStartTime = startTime;
+		fixedEndTime = endTime;
+	);
+
+	For(i=1, i<=NItems(pointIDs), i++,
+		archiveValues = ns:GetArchiveValues(pointIDs[i], fixedStartTime, fixedEndTime);
+		pointName = pointNames[i];
+		For(j=1, j<=nItems(archiveValues), j++,
+			result = archiveValues[j];
+			row = Eval(EvalExpr(
+				{
+					tag = Expr(pointName),
+					time = Expr(ns:ParseDateString(result["Timestamp"])),
+					status = Expr(ns:ExtractStatus(result))
+				}
+			));
+			// Add Value to value or svalue depending on type
+			If(IsString(result["Value"]),
+				InsertInto(row, EvalExpr(svalue = Expr(result["Value"])))
+			,IsNumber(result["Value"]),
+				InsertInto(row, EvalExpr(value = Expr(result["Value"])))
+			);
+			dt << AddRows(row);
+		);
+	);
+	return(dt)
+);
+
+// Breaks up a range from start to an end time for the given interval into several start and end times
+// to work around the hard API row limit of (endTime-startTime)/interval <= 150000
+ns:GetValidStartAndEndTimes = function({startTime, endTime, interval, endInclusive=1},
+	{DEFAULT LOCAL},
+	{interval} = ns:PiDurationToSeconds(evalList({interval}));
+	{startTime, endTime} = ns:PiTimeToTimestamp(evalList({startTime, endTime}), 1);
+	totalTime = endTime-startTime;
+	newStartTime = startTime;
+	newTimes = {};
+	while(1,
+		newEndTime = newStartTime + (interval * (ns:maxCount - 1 + endInclusive));
+		newTimeRange = evalList({ns:ToDateString(newStartTime), ns:ToDateString(newEndTime)});
+		insertInto(newTimes, evalList({newTimeRange}));
+		if(newEndTime-startTime >= totalTime,
+			// Make sure the last time is exactly the original endTime
+			newTimes[nItems(newtimes)][2] = ns:ToDateString(endTime);
+
+			// If the final range's duration is less than the interval, remove it from the list of ranges
+			If(endInclusive & endTime - newStartTime <= interval,
+				removeFrom(newTimes, -1)
+			);
+			Break()
+		);
+		newStartTime = newEndTime + if(endInclusive, 0, interval);
+	);
+	Return(newTimes)
+);
+
+// Get a list of interpolated values for the given pointID for all ranges provided
+// Example ranges: {{startdate1, enddate1}, {startdate2, enddate2}}
+// https://docs.osisoft.com/bundle/pi-web-api-reference/page/help/controllers/stream/actions/getinterpolated.html
+ns:GetInterpolatedValues = function({pointID, ranges, interval},
+	{DEFAULT LOCAL},
+	parameters = AssociativeArray();
+	parameters["selectedFields"] = "Items";
+	parameters["interval"] = interval;
+
+	endpoint = "streams/" || pointID || "/interpolated";
+	interpolatedValues = {};
+	for(i=1, i<=nItems(ranges), i++,
+		parameters["startTime"] = ranges[i][1];
+		parameters["endTime"] = ranges[i][2];
+		result = ns:GetRequest(endpoint, parameters);
+		items = result["Items"];
+		InsertInto(interpolatedValues, items);
+
+		// Break if the user's limit is reached
+		If(nItems(interpolatedValues) >= ns:maxRows,
+			Break()
+		);
+	);
+	Return(interpolatedValues)
+);
+
+// Get a table of interpolated values for each point in pointIDs between start and end times at the specified sampling interval
+ns:GetInterpolatedValuesTable = function({pointIDs, pointNames, startTime, endTime, interval},
+	{DEFAULT LOCAL},
+	dt = NewTable("Interpolated Values",
+		NewColumn( "tag", Character),
+		NewColumn( "time",  Numeric, Format("m/d/y h:m:s"), InputFormat("m/d/y h:m:s")),
+		NewColumn( "value", Numeric),
+		NewColumn( "svalue", Character),
+		NewColumn( "status", Character)
+	);
+
+	ranges = ns:GetValidStartAndEndTimes(startTime, endTime, interval, endInclusive=0);
+
+	For(i=1, i<=NItems(pointIDs), i++,
+		interpolatedValues = ns:GetInterpolatedValues(pointIDs[i], ranges, interval);
+		pointName = pointNames[i];
+		For(j=1, j<=nItems(interpolatedValues), j++,
+			result = interpolatedValues[j];
+			row = Eval(EvalExpr(
+				{
+					tag = Expr(pointName),
+					time = Expr(ns:ParseDateString(result["Timestamp"])),
+					status = Expr(ns:ExtractStatus(result))
+				}
+			));
+			// Add Value to value or svalue depending on type
+			If(IsString(result["Value"]),
+				InsertInto(row, EvalExpr(svalue = Expr(result["Value"])))
+			,IsNumber(result["Value"]),
+				InsertInto(row, EvalExpr(value = Expr(result["Value"])))
+			);
+			dt << AddRows(row);
+		);
+	);
+	return(dt)
+);
+
+// Get a list of summary values for the given pointID for all ranges provided
+// Example ranges: {{startdate1, enddate1}, {startdate2, enddate2}}
+// https://docs.osisoft.com/bundle/pi-web-api-reference/page/help/controllers/stream/actions/getsummary.html
+ns:GetSummaryValues = function({pointID, ranges, interval, summaryType, calculationBasis},
+	{DEFAULT LOCAL},
+	parameters = AssociativeArray();
+	parameters["selectedFields"] = "Items.Value";
+	parameters["summaryType"] = summaryType;
+	parameters["calculationBasis"] = calculationBasis;
+	parameters["summaryDuration"] = interval;
+	parameters["timeType"] = "MostRecentTime";
+
+	endpoint = "streams/" || pointID || "/summary";
+	summaryValues = {};
+	for(i=1, i<=nItems(ranges), i++,
+		parameters["startTime"] = ranges[i][1];
+		parameters["endTime"] = ranges[i][2];
+		result = ns:GetRequest(endpoint, parameters);
+		items = result["Items"];
+		InsertInto(summaryValues, items);
+
+		// Break if the user's limit is reached
+		If(nItems(summaryValues) >= ns:maxRows,
+			Break()
+		);
+	);
+	Return(summaryValues)
+);
+
+// Get a table of summary values for each point in pointIDs
+ns:GetSummaryValuesTable = Function({pointIDs, pointNames, summaryType, calculationBasis, startTime, endTime, interval, private=0},
+	{DEFAULT LOCAL},
+	eval(evalExpr(
+		dt = NewTable("Summary Values - " || summaryType,
+			NewColumn( "tag", Character),
+			NewColumn( "time",  Numeric, Format("m/d/y h:m:s"), InputFormat("m/d/y h:m:s")),
+			NewColumn( "value", Numeric),
+			expr(if(private, "private"))
+		);
+	));
+
+	ranges = ns:GetValidStartAndEndTimes(startTime, endTime, interval, endInclusive=1);
+
+	For(i=1, i<=NItems(pointIDs), i++,
+		pointName = pointNames[i];
+		pointResults = ns:GetSummaryValues(pointIDs[i], ranges, interval, summaryType, calculationBasis);
+		For(j=1, j<=NItems(pointResults), j++,
+			pointResult = pointResults[j];
+			row = Eval(EvalExpr(
+				{
+					tag = Expr(pointName),
+					time = Expr(ns:ParseDateString(pointResult["Value"]["Timestamp"])),
+					value = Expr(pointResult["Value"]["Value"])
+				}
+			));
+			dt << AddRows(row);
+		);
+	);
+	Return(dt)
+);
+
+// Calculate the greatest common divisor of two numbers
+ns:GreatestCommonDivisor = function({a, b},
+	{DEFAULT LOCAL},
+	if(a < b,
+		temp = a;
+		a = b;
+		b = temp;
+	);
+	r = mod(a, b);
+	if(r == 0,
+		return(b)
+	,
+		recurse(b, r);
+	);
+);
+
+// Get a table of summary values for each point in pointIDs where a stepTime is provided.
+// The rows of the table should be from startTime to endTime with increments of stepTime duration.
+// The summary statistics should be calculated from each of these times (t) from t-interval to t
+ns:GetSummaryValuesTableWithStepTime = Function({pointIDs, pointNames, summaryType, calculationBasis, startTime, endTime, interval, stepTime},
+	{DEFAULT LOCAL},
+
+	// If the step time and interval are the same, it's as if there is no step time
+	If(interval == stepTime,
+		Return(ns:GetSummaryValuesTable(pointIDs, pointNames, summaryType, calculationBasis, startTime, endTime, interval))
+	);
+
+	if(calculationBasis != "TimeWeighted", throw("Step time is only supported with the 'TimeWeighted' calculation basis."));
+
+	// Get a table of intended times from startTime to endTime in stepTime increments
+	{intervalSeconds, stepTimeSeconds} = ns:PiDurationToSeconds(evalList({interval, stepTime}));
+	{startTimeSeconds, endTimeSeconds} = ns:PiTimeToTimestamp(evalList({startTime, endTime}), 1);
+	dtSummary = AsTable((startTimeSeconds::endTimeSeconds::stepTimeSeconds)`);
+	column(dtSummary, 1) << setName("time") << setDataType(Numeric, Format("m/d/y h:m:s"));
+
+	// Repeat summary value requests with the specified interval at different offsets
+	// to get summary values at all times in the above table
+	gcd = ns:GreatestCommonDivisor(intervalSeconds, stepTimeSeconds);
+	nOffsets = intervalSeconds / gcd;
+	for(i=1, i<=nOffsets, i++,
+		offsetStartTime = ns:ToDateString(startTimeSeconds - gcd * i);
+		// Get summary values for the offset start time
+		dtTemp = ns:GetSummaryValuesTable(pointIDs, pointNames, "Average", "TimeWeighted", offsetStartTime, endTime, interval, private=1);
+		// Join the summary values into the table of times
+		dtJoin = dtSummary << Join(
+			With(dtTemp),
+			Merge Same Name Columns,
+			Match Flag( 0 ),
+			By Matching Columns( :time = :time ),
+			Drop multiples( 0, 0 ),
+			Include Nonmatches( 1, 0 ),
+			Preserve main table order( 1 )
+		);
+		close(dtSummary, "nosave");
+		close(dtTemp, "nosave");
+		dtSummary = dtJoin;
+	);
+
+	dtSummary << setName("Summary Values - " || summaryType);
+	dtSummary << Sort(
+		By( :tag ),
+		Order( Ascending ),
+		ReplaceTable
+	);
+	dtSummary << newDataView;
+	Return(dtSummary)
+);

--- a/README.md
+++ b/README.md
@@ -35,3 +35,5 @@ About: Steps
 - Commit changes in git and push commits to github.
 - Open a pull request on github
 
+## Contributors
+- [Predictum Inc.](https://predictum.com/)


### PR DESCRIPTION
Entirely replaces the ODBC backend with a web API backend while retaining existing functionality. See web API documentation [here](https://docs.osisoft.com/bundle/pi-web-api-reference/page/help.html). 

The user only needs to provide the base URL to their PI Web API e.g. https://mypiserver/piwebapi and the name of their data server.

queries.jsl has all code relevant to performing the necessary web requests. Links were provided to the relevant web API documentation where possible.

Resolves https://github.com/himanga/JMPOSIPITools/issues/1

Signed-off-by: Ben Peachey Higdon <bpeachey@predictum.com>